### PR TITLE
adjusted resource requests and limits for crossplane operator and aws…

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,10 @@
 aws:
   s3:
     roleARN: arn:aws:iam::737742117295:role/assume_s3_access
+crossplane:
+  resourcesCrossplane:
+    requests:
+      memory: 320Mi
 providers:
   awsS3:
     image:
@@ -13,7 +17,7 @@ providers:
         memory: 320Mi
       requests:
         cpu: 50m
-        memory: 128Mi
+        memory: 160Mi
   default:
     resources:
       limits:


### PR DESCRIPTION
This pull request includes changes to the `values.yaml` file to update resource requests and limits for AWS services. The most important changes include adding a new configuration for Crossplane resources and adjusting memory requests for AWS providers.

Resource configuration updates:

* [`values.yaml`](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR4-R7): Added a new configuration section for Crossplane resources, specifying memory requests.
* [`values.yaml`](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL16-R20): Updated memory requests for AWS providers from 128Mi to 160Mi.… provider