### PR TITLE
Increase memory limit for resources in `values.yaml` to 384Mi.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ providers:
     resources:
       limits:
         cpu: 250m
-        memory: 320Mi
+        memory: 384Mi
       requests:
         cpu: 50m
         memory: 128Mi


### PR DESCRIPTION
- Updated `memory` limit from 320Mi to 384Mi